### PR TITLE
Quickfix: Pass internal and external addresses so IGD is not attempted on D.O. droplets

### DIFF
--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -5,6 +5,7 @@ provider "registry.terraform.io/digitalocean/digitalocean" {
   version = "2.5.1"
   hashes = [
     "h1:UMxJ1MfOdamlVx4AGInfiZu5mCJyi5PW+8ct03kEQZs=",
+    "h1:k9itTwJzUpMBTYsXYPoEW/fyoDOcteQc4+OMRmFErbc=",
     "zh:057b8fa0f95213e7d856208d456175335fb673cfef14abf41193f0a2d76e1210",
     "zh:0daee13dd46de95ce2550459942c1433290798bfb5faac12781f81799dd6b05c",
     "zh:13778c00db5c43b2ed5781e2de32d73f34b391c865a52ad3380714bf86251785",

--- a/down.sh
+++ b/down.sh
@@ -1,5 +1,5 @@
 script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd -P)
 
-terraform destroy -var "do_token=${DO_PAT}" -var "pvt_key=${1}"
+terraform destroy -var "do_token=${DO_PAT}" #-var "pvt_key=${1}"
 
 rm ip-list || true

--- a/genesis.tf
+++ b/genesis.tf
@@ -11,7 +11,7 @@ resource "digitalocean_droplet" "sn_genesis" {
         user = "root"
         type = "ssh"
         timeout = "2m"
-        private_key = file(var.pvt_key)
+        #private_key = file(var.pvt_key)
     }
 
 
@@ -35,7 +35,7 @@ resource "digitalocean_droplet" "sn_genesis" {
       "export ${var.remote_log_level}",
       # "export RUST_BACKTRACE=1",
       # Do we still need rm here? wouldn't exist at this point
-      "nohup 2>&1 ./sn_node --first --ip ${digitalocean_droplet.sn_genesis.ipv4_address} --root-dir ~/node_data -vvvvv &",
+      "nohup 2>&1 ./sn_node --first --local-ip ${digitalocean_droplet.sn_genesis.ipv4_address} --local-port 5466 --external-ip ${digitalocean_droplet.sn_genesis.ipv4_address} --external-port 5466 --root-dir ~/node_data -vvvvv &",
       "sleep 5;"
     ]
   }

--- a/node.tf
+++ b/node.tf
@@ -13,7 +13,7 @@ resource "digitalocean_droplet" "sn_node" {
         user = "root"
         type = "ssh"
         timeout = "2m"
-        private_key = file(var.pvt_key)
+        #private_key = file(var.pvt_key)
 
     }
 
@@ -41,13 +41,13 @@ resource "digitalocean_droplet" "sn_node" {
       "export ${var.remote_log_level}",
       # "export RUST_BACKTRACE=1",
       "MAX_CAPACITY=$((${var.max_capacity}))",
-      "HARD_CODED_CONTACTS='[\"${digitalocean_droplet.sn_genesis.ipv4_address}:12000\"]'",
+      "HARD_CODED_CONTACTS='[\"${digitalocean_droplet.sn_genesis.ipv4_address}:5466\"]'",
       "echo hcc-$HARD_CODED_CONTACTS",
       "sleep 5",
       # "sleep $((${count.index * 2}));",
       "echo \"Starting node w/ capacity $MAX_CAPACITY\"",
       "echo \" node command is: sn_node --max-capacity $MAX_CAPACITY --root-dir ~/node_data --hard-coded-contacts $HARD_CODED_CONTACTS -vvvvv &\"",
-      "nohup 2>&1 ./sn_node --max-capacity $MAX_CAPACITY --root-dir ~/node_data --hard-coded-contacts $HARD_CODED_CONTACTS -vvvvv &",
+      "nohup 2>&1 ./sn_node --max-capacity $MAX_CAPACITY --root-dir ~/node_data --hard-coded-contacts $HARD_CODED_CONTACTS -vvvvv --local-ip ${self.ipv4_address} --local-port 5466 --external-ip ${self.ipv4_address} --external-port 5466 &",
       "sleep 5",
       "echo 'node ${count.index + 1} set up'"
     ]

--- a/provider.tf
+++ b/provider.tf
@@ -17,7 +17,7 @@ terraform {
 variable "do_token" {}
 
 # location of ssh key to log into nodes
-variable "pvt_key" {}
+#variable "pvt_key" {}
 
 variable "number_of_nodes" {
   default = "5"

--- a/src/download-node.sh
+++ b/src/download-node.sh
@@ -2,7 +2,8 @@
 
 echo "Downloading node bindary to nodes"
 node_version="latest"
-node_url="https://sn-node.s3.eu-west-2.amazonaws.com/sn_node-${node_version}-x86_64-unknown-linux-musl.tar.gz"
+#node_url="https://sn-node.s3.eu-west-2.amazonaws.com/sn_node-${node_version}-x86_64-unknown-linux-musl.tar.gz"
+node_url="https://github.com/lionel1704/sn_node/releases/download/0.25.1/sn_node"
 wget ${node_url}
-tar xf sn_node-${node_version}-x86_64-unknown-linux-musl.tar.gz
+#tar xf sn_node-${node_version}-x86_64-unknown-linux-musl.tar.gz
 echo "Node bin downloaded"

--- a/up.sh
+++ b/up.sh
@@ -9,7 +9,7 @@ node_capacity=${1:-$TWO_MB}
 
 terraform apply \
      -var "do_token=${DO_PAT}" \
-     -var "pvt_key=${1}" \
+     # -var "pvt_key=${1}" \
      -var "number_of_nodes=${NODE_OF_NODES}" \
      -var "node_bin=${3}"
 


### PR DESCRIPTION
This PR also contains some changes that removes the use of pvt key.

The RSA private key is sometimes password protected, so we should be able to use the ssh-agent to authenticate ourselves using said private key.