### PR TITLE
fix: Remove Debugging Change

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 SHELL := /bin/bash
 SN_TESTNET_SSH_KEY_PATH := ~/.ssh/id_rsa
-SN_TESTNET_NO_OF_NODES := 20
+SN_TESTNET_NO_OF_NODES := 15
 
 alpha:
 	rm -rf .terraform

--- a/genesis.tf
+++ b/genesis.tf
@@ -11,7 +11,7 @@ resource "digitalocean_droplet" "testnet_genesis" {
         user = "root"
         type = "ssh"
         timeout = "10m"
-        #private_key = file(var.pvt_key)
+        private_key = file(var.pvt_key)
     }
 
 

--- a/node.tf
+++ b/node.tf
@@ -13,8 +13,7 @@ resource "digitalocean_droplet" "testnet_node" {
         user = "root"
         type = "ssh"
         timeout = "10m"
-        #private_key = file(var.pvt_key)
-
+        private_key = file(var.pvt_key)
     }
 
     # depends_on = [


### PR DESCRIPTION
This looks like it had been commented out for debugging or something like that, but it was preventing SSH from working correctly.

Also change the default number of nodes from 20 to 15, as it can sometimes take quite long to spin up 20 nodes.