### PR TITLE
fix: Pass `--local-addr` to `sn_node`

### DIFF
--- a/node.tf
+++ b/node.tf
@@ -49,7 +49,7 @@ resource "digitalocean_droplet" "testnet_node" {
         # "sleep $((${count.index * 2}));",
         "echo \"Starting node w/ capacity $MAX_CAPACITY\"",
         "echo \" node command is: sn_node --max-capacity $MAX_CAPACITY --root-dir ~/node_data --hard-coded-contacts $HARD_CODED_CONTACTS --skip-igd ${var.remote_log_level} --log-dir ~/logs --json-logs &\"",
-        "nohup ./sn_node --max-capacity $MAX_CAPACITY --root-dir ~/node_data --hard-coded-contacts $HARD_CODED_CONTACTS --skip-igd ${var.remote_log_level} --log-dir ~/logs --json-logs &",
+        "nohup ./sn_node --max-capacity $MAX_CAPACITY --root-dir ~/node_data --hard-coded-contacts $HARD_CODED_CONTACTS --skip-igd ${var.remote_log_level} --log-dir ~/logs --json-logs --local-addr ${self.ipv4_address}:${var.port} &",
         "sleep 5",
         "echo 'node ${count.index + 1} set up'"
       ]


### PR DESCRIPTION
- d1d3cd1 **fix: Pass `--local-addr` to `sn_node`**

  The `sn_node` CLI now defaults to `127.0.0.1` for local address, rather
  than `0.0.0.0`, so we need to supply a value if we want external
  reachability. We use the node's actual IP rather than `0.0.0.0` due to a
  curious behaviour in `sn_node` where it may use the local address as the
  public address.
