### PR TITLE
feat(gha-support): add working dir variable

### DIFF
--- a/down.sh
+++ b/down.sh
@@ -7,7 +7,7 @@ then
 fi
 
 DEFAULT_WORKING_DIR="."
-WORKING_DIR="${GITHUB_ACTION_PATH:-$DEFAULT_WORKING_DIR}"
+WORKING_DIR="${WORKING_DIR:-$DEFAULT_WORKING_DIR}"
 
 script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd -P)
 TESTNET_CHANNEL=$(terraform workspace show)

--- a/down.sh
+++ b/down.sh
@@ -6,9 +6,12 @@ then
     exit
 fi
 
+DEFAULT_WORKING_DIR="."
+WORKING_DIR="${GITHUB_ACTION_PATH:-$DEFAULT_WORKING_DIR}"
+
 script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd -P)
 TESTNET_CHANNEL=$(terraform workspace show)
 AUTO_APPROVE=${2}
 
-terraform destroy -var "do_token=${DO_PAT}" -var "pvt_key=${1}"  --parallelism 15 ${AUTO_APPROVE} && \
-    rm ${TESTNET_CHANNEL}-ip-list || true
+terraform destroy -var "do_token=${DO_PAT}" -var "pvt_key=${1}" -var "working_dir=${WORKING_DIR}" --parallelism 15 ${AUTO_APPROVE} && \
+    rm ${WORKING_DIR}/${TESTNET_CHANNEL}-ip-list || true

--- a/down.sh
+++ b/down.sh
@@ -15,3 +15,9 @@ AUTO_APPROVE=${2}
 
 terraform destroy -var "do_token=${DO_PAT}" -var "pvt_key=${1}" -var "working_dir=${WORKING_DIR}" --parallelism 15 ${AUTO_APPROVE} && \
     rm ${WORKING_DIR}/${TESTNET_CHANNEL}-ip-list || true
+
+aws s3 rm "s3://safe-testnet-tool/$testnet_channel-ip-list"
+
+aws s3 rm "s3://safe-testnet-tool/$testnet_channel-genesis-ip"
+
+aws s3 rm "s3://safe-testnet-tool/$testnet_channel-node_connection_info.config"

--- a/genesis.tf
+++ b/genesis.tf
@@ -40,12 +40,12 @@ resource "digitalocean_droplet" "testnet_genesis" {
   }
 
    provisioner "local-exec" {
-    command = "echo ${digitalocean_droplet.testnet_genesis.ipv4_address} > ${terraform.workspace}-ip-list"
+    command = "echo ${digitalocean_droplet.testnet_genesis.ipv4_address} > ${var.working_dir}/${terraform.workspace}-ip-list"
          
   }
 
    provisioner "local-exec" {
-    command = "echo ${digitalocean_droplet.testnet_genesis.ipv4_address} > ${terraform.workspace}-genesis-ip"
+    command = "echo ${digitalocean_droplet.testnet_genesis.ipv4_address} > ${var.working_dir}/${terraform.workspace}-genesis-ip"
          
   }
 }

--- a/node.tf
+++ b/node.tf
@@ -56,7 +56,7 @@ resource "digitalocean_droplet" "testnet_node" {
   }
 
   provisioner "local-exec" {
-    command = "echo ${self.ipv4_address} >> ${terraform.workspace}-ip-list"
+    command = "echo ${self.ipv4_address} >> ${var.working_dir}/${terraform.workspace}-ip-list"
     on_failure = continue
   }
 

--- a/provider.tf
+++ b/provider.tf
@@ -27,6 +27,8 @@ variable "testnet_channel" {
   default = "public"
 }
 
+variable "working_dir" {}
+
 
 variable "node_bin" {
   default = ""

--- a/scripts/get-connection-infos
+++ b/scripts/get-connection-infos
@@ -6,7 +6,7 @@ trap cleanup SIGINT SIGTERM ERR EXIT
 
 TESTNET_CHANNEL=$(terraform workspace show)
 DEFAULT_WORKING_DIR="."
-WORKING_DIR="${GITHUB_ACTION_PATH:-$DEFAULT_WORKING_DIR}"
+WORKING_DIR="${WORKING_DIR:-$DEFAULT_WORKING_DIR}"
 
 script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd -P)
 

--- a/scripts/get-connection-infos
+++ b/scripts/get-connection-infos
@@ -5,6 +5,8 @@ set -Eeuo pipefail
 trap cleanup SIGINT SIGTERM ERR EXIT
 
 TESTNET_CHANNEL=$(terraform workspace show)
+DEFAULT_WORKING_DIR="."
+WORKING_DIR="${GITHUB_ACTION_PATH:-$DEFAULT_WORKING_DIR}"
 
 script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd -P)
 
@@ -13,30 +15,30 @@ cleanup() {
   # script cleanup here
 }
 
-rm -rf ${TESTNET_CHANNEL}-connection-infos || true
+rm -rf ${WORKING_DIR}/${TESTNET_CHANNEL}-connection-infos || true
 
-mkdir -p ${TESTNET_CHANNEL}-connection-infos
-for ip in $(<${TESTNET_CHANNEL}-ip-list xargs); do
-        rsync root@${ip}:~/.safe/node/node_connection_info.config ${TESTNET_CHANNEL}-connection-infos/${ip}.info &
+mkdir -p ${WORKING_DIR}/${TESTNET_CHANNEL}-connection-infos
+for ip in $(<${WORKING_DIR}/${TESTNET_CHANNEL}-ip-list xargs); do
+        rsync root@${ip}:~/.safe/node/node_connection_info.config ${WORKING_DIR}/${TESTNET_CHANNEL}-connection-infos/${ip}.info &
 done
 wait
 
 echo "Downloaded connection info files"
 
 infos=()
-echo "[" > ${TESTNET_CHANNEL}-node_connection_info.config
+echo "[" > ${WORKING_DIR}/${TESTNET_CHANNEL}-node_connection_info.config
 
-for file in $(ls ${TESTNET_CHANNEL}-connection-infos); do
-    infos+=($(cat ${TESTNET_CHANNEL}-connection-infos/$file | head -2 | tail -1))
+for file in $(ls ${WORKING_DIR}/${TESTNET_CHANNEL}-connection-infos); do
+    infos+=($(cat ${WORKING_DIR}/${TESTNET_CHANNEL}-connection-infos/$file | head -2 | tail -1))
 done
 
 for info in "${infos[@]}"; do
-        echo "$info," >> ${TESTNET_CHANNEL}-node_connection_info.config
+        echo "$info," >> ${WORKING_DIR}/${TESTNET_CHANNEL}-node_connection_info.config
 done
 
 # replace the last (two) chars which are ,\n
-truncate -s-2 ${TESTNET_CHANNEL}-node_connection_info.config
+truncate -s-2 ${WORKING_DIR}/${TESTNET_CHANNEL}-node_connection_info.config
 
-echo "]" >> ${TESTNET_CHANNEL}-node_connection_info.config
+echo "]" >> ${WORKING_DIR}/${TESTNET_CHANNEL}-node_connection_info.config
 
 cleanup

--- a/scripts/register_keys.sh
+++ b/scripts/register_keys.sh
@@ -3,7 +3,7 @@
 script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd -P)
 TESTNET_CHANNEL=$(terraform workspace show)
 DEFAULT_WORKING_DIR="."
-WORKING_DIR="${GITHUB_ACTION_PATH:-$DEFAULT_WORKING_DIR}"
+WORKING_DIR="${WORKING_DIR:-$DEFAULT_WORKING_DIR}"
 
 #  ensure ips are registered
 echo "Registering node keys w/ system"

--- a/scripts/register_keys.sh
+++ b/scripts/register_keys.sh
@@ -2,12 +2,16 @@
 
 script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd -P)
 TESTNET_CHANNEL=$(terraform workspace show)
+DEFAULT_WORKING_DIR="."
+WORKING_DIR="${GITHUB_ACTION_PATH:-$DEFAULT_WORKING_DIR}"
 
 #  ensure ips are registered
 echo "Registering node keys w/ system"
+mkdir -p ~/.ssh
+touch ~/.ssh/known_hosts
 while read -r ip; do
     ssh-keyscan -H ${ip} >> ~/.ssh/known_hosts
-done < ${TESTNET_CHANNEL}-ip-list
+done < ${WORKING_DIR}/${TESTNET_CHANNEL}-ip-list
 wait
 
 echo "Keys registered"

--- a/up.sh
+++ b/up.sh
@@ -7,6 +7,8 @@ NODE_OF_NODES=${2:-1}
 NODE_BIN=${3}
 NODE_VERSION=${4}
 AUTO_APPROVE=${5}
+DEFAULT_WORKING_DIR="."
+WORKING_DIR="${GITHUB_ACTION_PATH:-$DEFAULT_WORKING_DIR}"
 
 function check_dependencies() {
     set +e
@@ -60,17 +62,19 @@ function run_terraform_apply() {
          -var "pvt_key=${SSH_KEY_PATH}" \
          -var "number_of_nodes=${NODE_OF_NODES}" \
          -var "node_bin=${node_bin_path}" \
+         -var "working_dir=${WORKING_DIR}" \
          --parallelism 15 ${AUTO_APPROVE}
 }
 
 function copy_ips_to_s3() {
     local testnet_channel=$(terraform workspace show)
+    echo "$WORKING_DIR/$testnet_channel-ip-list"
     aws s3 cp \
-        "$testnet_channel-ip-list" \
+        "$WORKING_DIR/$testnet_channel-ip-list" \
         "s3://safe-testnet-tool/$testnet_channel-ip-list" \
         --acl public-read
     aws s3 cp \
-        "$testnet_channel-genesis-ip" \
+        "$WORKING_DIR/$testnet_channel-genesis-ip" \
         "s3://safe-testnet-tool/$testnet_channel-genesis-ip" \
         --acl public-read
 }

--- a/up.sh
+++ b/up.sh
@@ -8,7 +8,7 @@ NODE_BIN=${3}
 NODE_VERSION=${4}
 AUTO_APPROVE=${5}
 DEFAULT_WORKING_DIR="."
-WORKING_DIR="${GITHUB_ACTION_PATH:-$DEFAULT_WORKING_DIR}"
+WORKING_DIR="${WORKING_DIR:-$DEFAULT_WORKING_DIR}"
 
 function check_dependencies() {
     set +e
@@ -82,6 +82,11 @@ function copy_ips_to_s3() {
 function update_local_state() {
     ./scripts/register_keys.sh
     ./scripts/get-connection-infos
+    local testnet_channel=$(terraform workspace show)
+    aws s3 cp \
+        "$WORKING_DIR/$testnet_channel-node_connection_info.config" \
+        "s3://safe-testnet-tool/$testnet_channel-node_connection_info.config" \
+        --acl public-read
 }
 
 check_dependencies


### PR DESCRIPTION
when running the tool on GH actions all files are not created in the
current directory. They are created at $GITHUB_ACTION_PATH. This commit
adds a working_dir variable to the terraform scripts which uses the
GITHUB_ACTION_PATH variable to create and access the files if specified
and defaults to the current dir if undefined (eg. while running locally)
