### PR TITLE
Fix file-lock errors and add tokio console support

### DIFF
--- a/build.tf
+++ b/build.tf
@@ -14,43 +14,16 @@ resource "digitalocean_droplet" "node_builder" {
         timeout = "10m"
         private_key = file(var.pvt_key)
     }
-
     provisioner "remote-exec" {
         inline = [
-           "apt-get update",
-            "apt-get install build-essential -y",
-            # "bash",
-            <<-EOT
-                while sudo fuser /var/lib/dpkg/lock >/dev/null 2>&1 ; do
-                    sleep 1
-                done
-                while sudo fuser /var/lib/dpkg/lock-frontend >/dev/null 2>&1 ; do
-                    sleep 1
-                done
-                while sudo fuser /var/lib/apt/lists/lock >/dev/null 2>&1 ; do
-                    sleep 1
-                done
-                while sudo fuser /var/lib/apt/lists/ >/dev/null 2>&1 ; do
-                    sleep 1
-                done
-                if [ -f /var/log/unattended-upgrades/unattended-upgrades.log ]; then
-                    while sudo fuser /var/log/unattended-upgrades/unattended-upgrades.log >/dev/null 2>&1 ; do
-                    sleep 1
-                    done
-                fi
-            EOT
-        ]
-    }
-    provisioner "remote-exec" {
-        inline = [
-        
+            "apt-get update",
+            "DEBIAN_FRONTEND=noninteractive apt-get -qq install musl-tools build-essential -y",
             "git clone https://github.com/${var.repo_owner}/safe_network -q",
             "cd safe_network",
             "git checkout ${var.commit_hash}",
             "curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -q --default-host x86_64-unknown-linux-gnu --default-toolchain stable --profile minimal -y",
             ". $HOME/.cargo/env",
             "rustup target add x86_64-unknown-linux-musl",
-            "apt -qq install musl-tools -y ",
             "cargo -q build --release --target=x86_64-unknown-linux-musl",
         ]
     }

--- a/genesis.tf
+++ b/genesis.tf
@@ -34,6 +34,7 @@ resource "digitalocean_droplet" "testnet_genesis" {
       inline = [
         "echo 'Setting ENV vars'",
         # "export RUST_LOG=safe_network=trace",
+        "export TOKIO_CONSOLE_BIND=${digitalocean_droplet.testnet_genesis.ipv4_address}:6669",
         "nohup ./sn_node --first --local-addr ${digitalocean_droplet.testnet_genesis.ipv4_address}:${var.port} --skip-auto-port-forwarding --root-dir ~/node_data --log-dir ~/logs --json-logs ${var.remote_log_level} &",
       "sleep 5;"
     ]

--- a/node.tf
+++ b/node.tf
@@ -82,6 +82,7 @@ resource "digitalocean_droplet" "testnet_node" {
         "echo 'Setting ENV vars'",
         # "export RUST_LOG=safe_network=trace,qp2p=trace",
         "MAX_CAPACITY=$((${var.max_capacity}))",
+        "export TOKIO_CONSOLE_BIND=${self.ipv4_address}:6669",
         "sleep 5",
         # "sleep $((${count.index * 2}));",
         "echo \"Starting node w/ capacity $MAX_CAPACITY\"",


### PR DESCRIPTION
- fix(build): add env variable to prevent file-lock failure for apt-get install commands
- feat(tokio-console): set TOKIO_CONSOLE_BIND env variable so the console can be accessed from outside the droplet
