### PR TITLE
feat: copy genesis dbc from genesis node

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,9 @@
 ip-list
 *-ip-list
 genesis-ip
+genesis-dbc
 *-genesis-ip
+*-genesis-dbc
 elders-ip-list
 adults-ip-list
 doctl*

--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -5,6 +5,7 @@ provider "registry.terraform.io/digitalocean/digitalocean" {
   version     = "2.21.0"
   constraints = "~> 2.0"
   hashes = [
+    "h1:gndflVS5/+cwQbVVI6NwwB3dYK7W2QkmZuWmFBH/0tI=",
     "h1:jfg+obdslZflCiHOpNT4zT2ijLyx5bWT8kWodG8mWvw=",
     "zh:122a4e7aa7315be52c484fa9b8e8681a42ad17e1f892ca17d6aeb575902df078",
     "zh:192f9428d965d1a5d2629e6ec1c238c6815601fbc909f905bf94ff9359ba88f6",

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ alpha:
 	[[ ! -d "~/.safe/prefix_maps" ]] && mkdir -p ~/.safe/prefix_maps
 	rm -f ~/.safe/prefix_maps/alpha-prefix-map
 	cp alpha-prefix-map ~/.safe/prefix_maps/alpha-prefix-map
-	ln -s "$HOME/.safe/prefix_maps/alpha-prefix-map" "$HOME/.safe/prefix_maps/alpha"
+	ln -s "$$HOME/.safe/prefix_maps/alpha-prefix-map" "$$HOME/.safe/prefix_maps/alpha"
 
 clean-alpha:
 	terraform workspace select alpha
@@ -34,7 +34,7 @@ beta:
 	[[ ! -d "~/.safe/prefix_maps" ]] && mkdir -p ~/.safe/prefix_maps
 	rm -f ~/.safe/prefix_maps/beta-prefix-map
 	cp beta-prefix-map ~/.safe/prefix_maps/beta-prefix-map
-	ln -s "$HOME/.safe/prefix_maps/beta-prefix-map" "$HOME/.safe/prefix_maps/beta"
+	ln -s "$$HOME/.safe/prefix_maps/beta-prefix-map" "$$HOME/.safe/prefix_maps/beta"
 
 clean-beta:
 	terraform workspace select beta

--- a/down.sh
+++ b/down.sh
@@ -2,8 +2,8 @@
 
 if ! command -v terraform &> /dev/null
 then
-    echo "terraform could not be found and is required"
-    exit
+  echo "terraform could not be found and is required"
+  exit
 fi
 
 DEFAULT_WORKING_DIR="."
@@ -13,11 +13,13 @@ script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd -P)
 TESTNET_CHANNEL=$(terraform workspace show)
 AUTO_APPROVE=${2}
 
-terraform destroy -var "do_token=${DO_PAT}" -var "pvt_key=${1}" -var "working_dir=${WORKING_DIR}" --parallelism 15 ${AUTO_APPROVE} && \
-    rm ${WORKING_DIR}/${TESTNET_CHANNEL}-ip-list || true
+terraform destroy \
+  -var "do_token=${DO_PAT}" \
+  -var "pvt_key=${1}" \
+  -var "working_dir=${WORKING_DIR}" \
+  --parallelism 15 ${AUTO_APPROVE} && \
+  rm ${WORKING_DIR}/${TESTNET_CHANNEL}-ip-list || true
 
 aws s3 rm "s3://safe-testnet-tool/$TESTNET_CHANNEL-ip-list"
-
 aws s3 rm "s3://safe-testnet-tool/$TESTNET_CHANNEL-genesis-ip"
-
 aws s3 rm "s3://safe-testnet-tool/$TESTNET_CHANNEL-prefix-map"

--- a/scripts/dl_files.sh
+++ b/scripts/dl_files.sh
@@ -13,14 +13,13 @@ cleanup() {
 
 count=0
 for line in $(<./tests/indexxx xargs); do
-      printf "  ===================== \n"
-      printf "safe cat-ting $line"
-      count=$((count+1))
-      cd $TMPDIR
-      time safe cat $line > "$TMPDIR/$count.jpg"
-      printf "\n dlded ==> $TMPDIR/$count.jpg \n\n"
+  printf "  ===================== \n"
+  printf "safe cat-ting $line"
+  count=$((count+1))
+  cd $TMPDIR
+  time safe cat $line > "$TMPDIR/$count.jpg"
+  printf "\n dlded ==> $TMPDIR/$count.jpg \n\n"
 done
-
 
 wait
 

--- a/scripts/droplet-operations
+++ b/scripts/droplet-operations
@@ -1,15 +1,15 @@
 #!/bin/bash
 
 function register_hosts {
-        while read -r ip
-        do
-                ssh-keyscan -H ${ip} >> ~/.ssh/known_hosts
-        done < ip-list
+  while read -r ip
+  do
+    ssh-keyscan -H ${ip} >> ~/.ssh/known_hosts
+  done < ip-list
 }
 
 function clear_safe_data {
-        for ip in $(<ip-list xargs); do
-                ssh -o "BatchMode yes" root@${ip} "pkill sn_node; rm -rf node_data; rm sn_node*" 1>"logs/$ip.log" 2>&1 &
-        done
-        wait
+  for ip in $(<ip-list xargs); do
+    ssh -o "BatchMode yes" root@${ip} "pkill sn_node; rm -rf node_data; rm sn_node*" 1>"logs/$ip.log" 2>&1 &
+  done
+  wait
 }

--- a/scripts/logs
+++ b/scripts/logs
@@ -17,7 +17,7 @@ cleanup() {
 
 mkdir -p logs/${TESTNET_CHANNEL}
 for ip in $(<${TESTNET_CHANNEL}-ip-list xargs); do
-        rsync -r -P root@${ip}:~/logs logs/${TESTNET_CHANNEL}/${ip} &
+  rsync -r -P root@${ip}:~/logs logs/${TESTNET_CHANNEL}/${ip} &
 done
 wait
 

--- a/scripts/read-all.sh
+++ b/scripts/read-all.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
 for address in $(ls addresses/data-address-*); do
-    safe cat $(jq -r '.[0]' $address)
-    safe cat $(jq -r '.[1][][1]' $address) > /dev/null
+  safe cat $(jq -r '.[0]' $address)
+  safe cat $(jq -r '.[1][][1]' $address) > /dev/null
 done

--- a/scripts/restart.sh
+++ b/scripts/restart.sh
@@ -9,7 +9,6 @@ GENESIS_IP=$( cat ${TESTNET_CHANNEL}-genesis-ip)
 # HARD_CODED_CONTACTS="[\"${GENESIS_IP}:12000\"]"
 HARD_CODED_CONTACTS='[\"'$GENESIS_IP':12000\"]'
 
-
 echo "restarting genesis node"
 
 ssh root@$GENESIS_IP 'pkill -f sn_node & rm ~/nohup.out || true && nohup 2>&1 ./sn_node --first '$GENESIS_IP':12000 --skip-igd --root-dir ~/node_data -vvvvv &' 
@@ -23,14 +22,12 @@ echo "Restarting all nodes w/ system"
 echo $MAX_CAPACITY
 echo $HARD_CODED_CONTACTS
 for ip in $(<${TESTNET_CHANNEL}-ip-list xargs); do
-
-    if [ "$ip" == "$GENESIS_IP" ]; then
-        echo "Not restarting genesis node again. Doing nothing here"
-    else
-        echo "restarting node at $ip"
-        ssh root@${ip} 'pkill -f sn_node & rm ~/nohup.out || true && nohup 2>&1 ./sn_node --max-capacity '$MAX_CAPACITY' --root-dir ~/node_data --hard-coded-contacts '$HARD_CODED_CONTACTS' -vvvvv --skip-igd &' &
-    fi
-
+  if [ "$ip" == "$GENESIS_IP" ]; then
+    echo "Not restarting genesis node again. Doing nothing here"
+  else
+    echo "restarting node at $ip"
+    ssh root@${ip} 'pkill -f sn_node & rm ~/nohup.out || true && nohup 2>&1 ./sn_node --max-capacity '$MAX_CAPACITY' --root-dir ~/node_data --hard-coded-contacts '$HARD_CODED_CONTACTS' -vvvvv --skip-igd &' &
+  fi
 done
 
 echo "All ${TESTNET_CHANNEL} Nodes restarted."

--- a/up.sh
+++ b/up.sh
@@ -79,18 +79,30 @@ function copy_ips_to_s3() {
     --acl public-read
 }
 
-function pull_latest_prefix_map_from_genesis_and_copy_to_s3() {
+function pull_prefix_map_and_copy_to_s3() {
   genesis_ip=$(cat "$WORKING_DIR/$testnet_channel-genesis-ip")
-  echo "Pulling latest PrefixMap from Genesis node"
-  rsync root@$(cat "$WORKING_DIR/$testnet_channel-genesis-ip"):~/.safe/prefix_maps/default "$WORKING_DIR/$testnet_channel-prefix-map"
+  prefix_map_path="$WORKING_DIR/$testnet_channel-prefix-map"
+  echo "Pulling PrefixMap from Genesis node"
+  rsync root@"$genesis_ip":~/.safe/prefix_maps/default "$prefix_map_path"
   aws s3 cp \
-    "$WORKING_DIR/$testnet_channel-prefix-map" \
+    "$prefix_map_path" \
     "s3://safe-testnet-tool/$testnet_channel-prefix-map" \
     --acl public-read
 }
 
+function pull_genesis_dbc_and_copy_to_s3() {
+  genesis_ip=$(cat "$WORKING_DIR/$testnet_channel-genesis-ip")
+  genesis_dbc_path="$WORKING_DIR/$testnet_channel-genesis-dbc"
+  echo "Pulling Genesis DBC from Genesis node"
+  rsync root@"$genesis_ip":~/node_data/genesis_dbc "$genesis_dbc_path"
+  aws s3 cp \
+    "$genesis_dbc_path" \
+    "s3://safe-testnet-tool/$testnet_channel-genesis-dbc" \
+    --acl public-read
+}
 
 check_dependencies
 run_terraform_apply
 copy_ips_to_s3
-pull_latest_prefix_map_from_genesis_and_copy_to_s3
+pull_prefix_map_and_copy_to_s3
+pull_genesis_dbc_and_copy_to_s3

--- a/up.sh
+++ b/up.sh
@@ -13,70 +13,70 @@ WORKING_DIR="${WORKING_DIR:-$DEFAULT_WORKING_DIR}"
 testnet_channel=$(terraform workspace show)
 
 function check_dependencies() {
-    set +e
-    declare -a dependecies=("terraform" "aws" "tar" "jq")
-    for dependency in "${dependecies[@]}"
-    do
-        if ! command -v "$dependency" &> /dev/null; then
-            echo "$dependency could not be found and is required"
-            exit 1
-        fi
-    done
-    set -e
+  set +e
+  declare -a dependecies=("terraform" "aws" "tar" "jq")
+  for dependency in "${dependecies[@]}"
+  do
+    if ! command -v "$dependency" &> /dev/null; then
+      echo "$dependency could not be found and is required"
+      exit 1
+    fi
+  done
+  set -e
 
-    if [[ -z "${DO_PAT}" ]]; then
-        echo "The DO_PAT env variable must be set with your personal access token."
-        exit 1
-    fi
-    if [[ -z "${AWS_ACCESS_KEY_ID}" ]]; then
-        echo "The AWS_ACCESS_KEY_ID env variable must be set with your access key ID."
-        exit 1
-    fi
-    if [[ -z "${AWS_SECRET_ACCESS_KEY}" ]]; then
-        echo "The AWS_SECRET_ACCESS_KEY env variable must be set with your secret access key."
-        exit 1
-    fi
-    if [[ -z "${AWS_DEFAULT_REGION}" ]]; then
-        echo "The AWS_DEFAULT_REGION env variable must be set. Default is usually eu-west-2."
-        exit 1
-    fi
-    if [[ ! -z "${NODE_VERSION}" && ! -z "${NODE_BIN}" ]]; then
-        echo "Both NODE_VERSION and NODE_BIN cannot be set at the same time."
-        echo "Please use one or the other."
-        exit 1
-    fi
+  if [[ -z "${DO_PAT}" ]]; then
+    echo "The DO_PAT env variable must be set with your personal access token."
+    exit 1
+  fi
+  if [[ -z "${AWS_ACCESS_KEY_ID}" ]]; then
+    echo "The AWS_ACCESS_KEY_ID env variable must be set with your access key ID."
+    exit 1
+  fi
+  if [[ -z "${AWS_SECRET_ACCESS_KEY}" ]]; then
+    echo "The AWS_SECRET_ACCESS_KEY env variable must be set with your secret access key."
+    exit 1
+  fi
+  if [[ -z "${AWS_DEFAULT_REGION}" ]]; then
+    echo "The AWS_DEFAULT_REGION env variable must be set. Default is usually eu-west-2."
+    exit 1
+  fi
+  if [[ ! -z "${NODE_VERSION}" && ! -z "${NODE_BIN}" ]]; then
+    echo "Both NODE_VERSION and NODE_BIN cannot be set at the same time."
+    echo "Please use one or the other."
+    exit 1
+  fi
 }
 
 function run_terraform_apply() {
-    local node_bin_path="${NODE_BIN}"
-    if [[ ! -z "${NODE_VERSION}" ]]; then
-        (
-            cd /tmp
-            rm -rf sn_node-${NODE_VERSION}
-            mkdir sn_node-${NODE_VERSION}
-            aws s3 cp s3://sn-node/sn_node-${NODE_VERSION}-x86_64-unknown-linux-musl.tar.gz .
-            tar -C sn_node-${NODE_VERSION} -xvf sn_node-${NODE_VERSION}-x86_64-unknown-linux-musl.tar.gz
-        )
-        node_bin_path="/tmp/sn_node-${NODE_VERSION}/sn_node"
-    fi
-    terraform apply \
-         -var "do_token=${DO_PAT}" \
-         -var "pvt_key=${SSH_KEY_PATH}" \
-         -var "number_of_nodes=${NODE_OF_NODES}" \
-         -var "node_bin=${node_bin_path}" \
-         -var "working_dir=${WORKING_DIR}" \
-         --parallelism 15 ${AUTO_APPROVE}
+  local node_bin_path="${NODE_BIN}"
+  if [[ ! -z "${NODE_VERSION}" ]]; then
+    (
+      cd /tmp
+      rm -rf sn_node-${NODE_VERSION}
+      mkdir sn_node-${NODE_VERSION}
+      aws s3 cp s3://sn-node/sn_node-${NODE_VERSION}-x86_64-unknown-linux-musl.tar.gz .
+      tar -C sn_node-${NODE_VERSION} -xvf sn_node-${NODE_VERSION}-x86_64-unknown-linux-musl.tar.gz
+    )
+    node_bin_path="/tmp/sn_node-${NODE_VERSION}/sn_node"
+  fi
+  terraform apply \
+    -var "do_token=${DO_PAT}" \
+    -var "pvt_key=${SSH_KEY_PATH}" \
+    -var "number_of_nodes=${NODE_OF_NODES}" \
+    -var "node_bin=${node_bin_path}" \
+    -var "working_dir=${WORKING_DIR}" \
+    --parallelism 15 ${AUTO_APPROVE}
 }
 
 function copy_ips_to_s3() {
-    aws s3 cp \
-        "$WORKING_DIR/$testnet_channel-ip-list" \
-        "s3://safe-testnet-tool/$testnet_channel-ip-list" \
-        --acl public-read
-    aws s3 cp \
-        "$WORKING_DIR/$testnet_channel-genesis-ip" \
-        "s3://safe-testnet-tool/$testnet_channel-genesis-ip" \
-        --acl public-read
+  aws s3 cp \
+    "$WORKING_DIR/$testnet_channel-ip-list" \
+    "s3://safe-testnet-tool/$testnet_channel-ip-list" \
+    --acl public-read
+  aws s3 cp \
+    "$WORKING_DIR/$testnet_channel-genesis-ip" \
+    "s3://safe-testnet-tool/$testnet_channel-genesis-ip" \
+    --acl public-read
 }
 
 function pull_latest_prefix_map_from_genesis_and_copy_to_s3() {
@@ -84,9 +84,9 @@ function pull_latest_prefix_map_from_genesis_and_copy_to_s3() {
   echo "Pulling latest PrefixMap from Genesis node"
   rsync root@$(cat "$WORKING_DIR/$testnet_channel-genesis-ip"):~/.safe/prefix_maps/default "$WORKING_DIR/$testnet_channel-prefix-map"
   aws s3 cp \
-          "$WORKING_DIR/$testnet_channel-prefix-map" \
-          "s3://safe-testnet-tool/$testnet_channel-prefix-map" \
-          --acl public-read
+    "$WORKING_DIR/$testnet_channel-prefix-map" \
+    "s3://safe-testnet-tool/$testnet_channel-prefix-map" \
+    --acl public-read
 }
 
 


### PR DESCRIPTION
- ebabed1 **chore: consistent indentation for scripts**

  According to Google's 'Shell Style Guide' (which most use for Bash), two spaces is the recommended
  indentation size.

  There's also a little fix in the Makefile for referencing shell variables correctly.

- ca04f9f **feat: copy genesis dbc from genesis node**

  Also makes some cosmetic changes for readability.