### PR TITLE
feat: suppress output from apt

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ SN_TESTNET_NODE_COUNT := 15
 SN_TESTNET_CLIENT_COUNT := 0
 
 alpha:
+	rm -f alpha-*
 	rm -rf .terraform
 	terraform init
 	terraform workspace select alpha
@@ -14,15 +15,17 @@ alpha:
 		"${SN_TESTNET_NODE_VERSION}" \
 		"${SN_TESTNET_CLIENT_COUNT}" \
 		"-auto-approve"
-	[[ ! -d "~/.safe/prefix_maps" ]] && mkdir -p ~/.safe/prefix_maps
-	rm -f ~/.safe/prefix_maps/alpha-prefix-map
+	rm -rf ~/.safe
+	mkdir -p ~/.safe/prefix_maps
 	cp alpha-prefix-map ~/.safe/prefix_maps/default
+	cp alpha-genesis-dbc ~/.safe/genesis_dbc
 
 clean-alpha:
 	terraform workspace select alpha
 	./down.sh "${SN_TESTNET_SSH_KEY_PATH}" "-auto-approve"
 
 beta:
+	rm -f beta-*
 	rm -rf .terraform
 	terraform init
 	terraform workspace select beta
@@ -33,9 +36,10 @@ beta:
 		"${SN_TESTNET_NODE_VERSION}" \
 		"${SN_TESTNET_CLIENT_COUNT}" \
 		"-auto-approve"
-	[[ ! -d "~/.safe/prefix_maps" ]] && mkdir -p ~/.safe/prefix_maps
-	rm -f ~/.safe/prefix_maps/beta-prefix-map
+	rm -rf ~/.safe
+	mkdir -p ~/.safe/prefix_maps
 	cp beta-prefix-map ~/.safe/prefix_maps/default
+	cp beta-genesis-dbc ~/.safe/genesis_dbc
 
 clean-beta:
 	terraform workspace select beta

--- a/scripts/ELK/install-and-run-metricbeat.sh
+++ b/scripts/ELK/install-and-run-metricbeat.sh
@@ -9,7 +9,9 @@ echo "deb [signed-by=/usr/share/keyrings/elasticsearch-keyring.gpg] https://arti
 
 # Update and install metricbeat
 echo "Installing Metricbeat"
-sudo apt-get update && sudo apt-get install metricbeat && sudo apt-get install rpl
+sudo apt-get update > /dev/null 2>&1
+sudo apt-get install metricbeat > /dev/null 2>&1
+sudo apt-get install rpl > /dev/null 2>&1
 
 # Remove default config
 rm -rf /etc/metricbeat/metricbeat.yml

--- a/scripts/init-node.sh
+++ b/scripts/init-node.sh
@@ -43,12 +43,12 @@ function install_heaptrack() {
   # Other times, the heaptrack package won't be available because it seems to
   # be some kind of timing issue: if you run the install command too quickly
   # after the update command, apt will complain it can't find the package.
-  sudo apt update
+  sudo apt update > /dev/null 2>&1
   retry_count=1
   heaptrack_installed="false"
   while [[ $retry_count -le 20 ]]; do
     echo "Attempting to install heaptrack..."
-    sudo apt install heaptrack -y
+    sudo apt install heaptrack -y > /dev/null 2>&1
     local exit_code=$?
     if [[ $exit_code -eq 0 ]]; then
         echo "heaptrack installed successfully"
@@ -60,7 +60,7 @@ function install_heaptrack() {
     ((retry_count++))
     sleep 10
     # Without running this again there are times when it will just fail on every retry.
-    sudo apt update
+    sudo apt update > /dev/null 2>&1
   done
   if [[ "$heaptrack_installed" == "false" ]]; then
     echo "Failed to install heaptrack"


### PR DESCRIPTION
The installation of various packages produces an enormous amount of text output that is largely of
no interest, and it makes the nightly logs difficult to sift through. Note that I tried various
switches like `-qq`, but there was nothing that worked across different versions of Ubuntu, so I
ended up just redirecting the output to `/dev/null`.

You'd only really be interested in seeing the output when the installs fail, but I'd say in that
case you can turn the output back on to see what is going on. If the package is on apt it should be
pretty stable anyway and an unlikely source of errors.

There are also a couple of changes to the Makefile targets here just to make sure all information
relating to the previous testnet are cleared out.