### PR TITLE
Debugging Improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,8 +3,10 @@ ip-list
 *-ip-list
 genesis-ip
 genesis-dbc
+genesis-key
 *-genesis-ip
 *-genesis-dbc
+*-genesis-key
 elders-ip-list
 adults-ip-list
 doctl*

--- a/down.sh
+++ b/down.sh
@@ -13,5 +13,4 @@ AUTO_APPROVE=${2}
 terraform destroy \
   -var "do_token=${DO_PAT}" \
   -var "pvt_key=${1}" \
-  --parallelism 15 ${AUTO_APPROVE} && \
-  rm ${TESTNET_CHANNEL}-ip-list || true
+  --parallelism 15 ${AUTO_APPROVE}

--- a/down.sh
+++ b/down.sh
@@ -15,7 +15,3 @@ terraform destroy \
   -var "pvt_key=${1}" \
   --parallelism 15 ${AUTO_APPROVE} && \
   rm ${TESTNET_CHANNEL}-ip-list || true
-
-aws s3 rm "s3://safe-testnet-tool/$TESTNET_CHANNEL-ip-list"
-aws s3 rm "s3://safe-testnet-tool/$TESTNET_CHANNEL-genesis-ip"
-aws s3 rm "s3://safe-testnet-tool/$TESTNET_CHANNEL-prefix-map"

--- a/genesis.tf
+++ b/genesis.tf
@@ -34,11 +34,12 @@ resource "digitalocean_droplet" "testnet_genesis" {
     command = <<EOH
       echo "node-1 ${digitalocean_droplet.testnet_genesis.ipv4_address}" > ${terraform.workspace}-ip-list
       echo ${digitalocean_droplet.testnet_genesis.ipv4_address} > ${terraform.workspace}-genesis-ip
-      rm ${terraform.workspace}-prefix-map || true
+      rm -f ${terraform.workspace}-prefix-map
       mkdir -p ~/.ssh/
       touch ~/.ssh/known_hosts
       ssh-keyscan -H ${digitalocean_droplet.testnet_genesis.ipv4_address} >> ~/.ssh/known_hosts
       rsync root@${digitalocean_droplet.testnet_genesis.ipv4_address}:~/prefix-map ${terraform.workspace}-prefix-map
+      rsync root@${digitalocean_droplet.testnet_genesis.ipv4_address}:~/genesis-key ${terraform.workspace}-genesis-key
     EOH
   }
 }

--- a/node.tf
+++ b/node.tf
@@ -45,29 +45,6 @@ resource "digitalocean_droplet" "testnet_node" {
 
   provisioner "local-exec" {
     command = <<EOH
-      if ! [ -f ${terraform.workspace}-prefix-map ]; then
-        echo "Downloading from s3://safe-testnet-tool/${terraform.workspace}-prefix-map to ${terraform.workspace}-prefix-map"
-        aws s3 cp \
-          "s3://safe-testnet-tool/${terraform.workspace}-prefix-map" \
-          "${terraform.workspace}-prefix-map"
-      fi
-      if ! [ -f ${terraform.workspace}-ip-list ]; then
-        echo "Downloading from s3://safe-testnet-tool/${terraform.workspace}-ip-list to ${terraform.workspace}-ip-list"
-        aws s3 cp \
-          "s3://safe-testnet-tool/${terraform.workspace}-ip-list" \
-          "${terraform.workspace}-ip-list"
-      fi
-      if ! [ -f ${terraform.workspace}-genesis-ip ]; then
-      echo "Downloading from s3://safe-testnet-tool/${terraform.workspace}-genesis-ip to ${terraform.workspace}-genesis-ip"
-        aws s3 cp \
-          "s3://safe-testnet-tool/${terraform.workspace}-genesis-ip" \
-          "${terraform.workspace}-genesis-ip"
-      fi
-    EOH
-  }
-
-  provisioner "local-exec" {
-    command = <<EOH
       mkdir -p ~/.ssh/
       touch ~/.ssh/known_hosts
       echo "node-${count.index + 2} ${self.ipv4_address}" >> ${terraform.workspace}-ip-list

--- a/scripts/init-node.sh
+++ b/scripts/init-node.sh
@@ -44,7 +44,6 @@ function install_heaptrack() {
   # be some kind of timing issue: if you run the install command too quickly
   # after the update command, apt will complain it can't find the package.
   sudo DEBIAN_FRONTEND=noninteractive apt update > /dev/null 2>&1
-  sudo DEBIAN_FRONTEND=noninteractive apt-get update -y
   retry_count=1
   heaptrack_installed="false"
   while [[ $retry_count -le 20 ]]; do
@@ -104,6 +103,11 @@ function run_node() {
     nohup sh -c "$node_cmd" &
     sleep 5
     cp -H ~/.safe/prefix_maps/default ~/prefix-map
+    (
+      cd ~/logs
+      grep --extended-regexp --only-matching --no-filename ".*Genesis node started.*" sn_node.log* |
+        awk -F ':' '{ print $2 }' | xargs > ~/genesis-key
+    )
     sleep 5
   else
     node_cmd=$(printf '%s' \

--- a/scripts/logs-sync.sh
+++ b/scripts/logs-sync.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# This is mainly intended to be used for debugging the nightly run.
+# It's expecting the ip list file to be in the same directory the script is running from.
+
+set -e
+
+testnet_channel="$1"
+if [[ -z "$testnet_channel" ]]; then
+  echo "The name of the testnet must be provided"
+  exit 1
+fi
+
+mkdir -p logs/${testnet_channel}
+
+cat ${testnet_channel}-ip-list | while read line; do
+  name=$(echo $line | awk '{print $1}')
+  ip=$(echo $line | awk '{print $2}')
+  echo "Getting $name logs from $ip"
+  rsync -v -r root@${ip}:~/logs logs/${testnet_channel}/${name}___${ip}
+done

--- a/up.sh
+++ b/up.sh
@@ -89,8 +89,8 @@ function copy_ips_to_s3() {
 }
 
 function pull_prefix_map_and_copy_to_s3() {
-  genesis_ip=$(cat "$testnet_channel-genesis-ip")
-  prefix_map_path="$testnet_channel-prefix-map"
+  local genesis_ip=$(cat "$testnet_channel-genesis-ip")
+  local prefix_map_path="$testnet_channel-prefix-map"
   echo "Pulling PrefixMap from Genesis node"
   rsync root@"$genesis_ip":~/.safe/prefix_maps/default "$prefix_map_path"
   aws s3 cp \
@@ -100,8 +100,8 @@ function pull_prefix_map_and_copy_to_s3() {
 }
 
 function pull_genesis_dbc_and_copy_to_s3() {
-  genesis_ip=$(cat "$testnet_channel-genesis-ip")
-  genesis_dbc_path="$testnet_channel-genesis-dbc"
+  local genesis_ip=$(cat "$testnet_channel-genesis-ip")
+  local genesis_dbc_path="$testnet_channel-genesis-dbc"
   echo "Pulling Genesis DBC from Genesis node"
   rsync root@"$genesis_ip":~/node_data/genesis_dbc "$genesis_dbc_path"
   aws s3 cp \
@@ -110,8 +110,20 @@ function pull_genesis_dbc_and_copy_to_s3() {
     --acl public-read
 }
 
+function pull_genesis_key_and_copy_to_s3() {
+  local genesis_ip=$(cat "$testnet_channel-genesis-ip")
+  local genesis_key_path="$testnet_channel-genesis-key"
+  echo "Pulling Genesis key from Genesis node"
+  rsync root@"$genesis_ip":~/genesis-key "$genesis_key_path"
+  aws s3 cp \
+    "$genesis_key_path" \
+    "s3://safe-testnet-tool/$testnet_channel-genesis-key" \
+    --acl public-read
+}
+
 check_dependencies
 run_terraform_apply
 copy_ips_to_s3
 pull_prefix_map_and_copy_to_s3
 pull_genesis_dbc_and_copy_to_s3
+pull_genesis_key_and_copy_to_s3


### PR DESCRIPTION
- 530659c **feat(node): provide genesis key from genesis node**

  When the genesis node starts up, the genesis key gets output to file by finding it from the logs.
  After the Terraform run it will then be copied from the genesis node to the local machine and also
  uploaded to S3, as per the IP lists and the prefix map.

  Having the genesis key can be useful for basic debugging. We had seen some errors that potentially
  indicated a mismatch between the genesis key on the node and the one being used by the client test
  runner process.

  The down script removed the prefix map and genesis information from S3, but I've taken this out,
  since having access to this information could be useful, particularly after a failed nightly run.

  There was also a local-exec provisioner that ran to download these files from S3 if they didn't
  exist on the local machine. I couldn't see what the purpose of this was, so I removed it. That
  information will get generated by the `up.sh` script.

- 845c3e4 **feat(debug): script for pulling logs**

  Based on the `logs` script, this one is very similar, it just operates in a synchronous way rather
  than launching rsync in the background.

  It's intended to be used mainly for debugging the nightly, so we will want to wait till all the logs
  have been downloaded before moving on to the next step.