### PR TITLE
feat(debug): script for pulling logs

### DIFF
--- a/scripts/logs-sync.sh
+++ b/scripts/logs-sync.sh
@@ -11,11 +11,16 @@ if [[ -z "$testnet_channel" ]]; then
   exit 1
 fi
 
+mkdir -p ~/.ssh/
+touch ~/.ssh/known_hosts
 mkdir -p logs/${testnet_channel}
-
 cat ${testnet_channel}-ip-list | while read line; do
   name=$(echo $line | awk '{print $1}')
   ip=$(echo $line | awk '{print $2}')
   echo "Getting $name logs from $ip"
-  rsync -v -r root@${ip}:~/logs logs/${testnet_channel}/${name}___${ip}
+  rsync \
+    --rsh="ssh -o StrictHostKeyChecking=no" \
+    --verbose \
+    --recursive \
+    root@${ip}:~/logs logs/${testnet_channel}/${name}___${ip}
 done

--- a/up.sh
+++ b/up.sh
@@ -78,6 +78,7 @@ function run_terraform_apply() {
 }
 
 function copy_ips_to_s3() {
+  # This is only really used for debugging the nightly run.
   aws s3 cp \
     "$testnet_channel-ip-list" \
     "s3://safe-testnet-tool/$testnet_channel-ip-list" \


### PR DESCRIPTION
Based on the `logs` script, this one is very similar, it just operates in a synchronous way rather
than launching rsync in the background.

It's intended to be used mainly for debugging the nightly, so we will want to wait till all the logs
have been downloaded before moving on to the next step.

Note that strict host key checking has been switched off for the rsync. I did try using ssh-keyscan,
but it didn't work in this context.