### PR TITLE
fix(script): continue on error for log sync

### DIFF
--- a/scripts/logs-sync.sh
+++ b/scripts/logs-sync.sh
@@ -3,8 +3,6 @@
 # This is mainly intended to be used for debugging the nightly run.
 # It's expecting the ip list file to be in the same directory the script is running from.
 
-set -e
-
 testnet_channel="$1"
 if [[ -z "$testnet_channel" ]]; then
   echo "The name of the testnet must be provided"


### PR DESCRIPTION
There was a problem with a nightly run where rsync returned an error due to a 'vanished' file, which
is one that was on its transfer list initially, but was subsequently deleted before it actually came
to be transferred. Even though rsync treats this as a warning, it still returns an non-zero exit
code, and you can't change that behaviour using an argument. This caused the run to fail before the
rest of the logs were transferred or the testnet was killed.

I tried a few different methods, but the simplest solution may just be to let the script continue on
errors, so `set -e` is removed.