### PR TITLE
fix: retain use of node bin path argument

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,8 @@ SN_TESTNET_NODE_COUNT := 15
 SN_TESTNET_CLIENT_COUNT := 0
 
 alpha:
-	rm -f alpha-*
+	rm -rf workspace/alpha
+	mkdir -p workspace/alpha
 	rm -rf .terraform
 	terraform init
 	terraform workspace select alpha
@@ -17,15 +18,16 @@ alpha:
 		"-auto-approve"
 	rm -rf ~/.safe
 	mkdir -p ~/.safe/network_contacts
-	cp alpha-network-contacts ~/.safe/network_contacts/default
-	cp alpha-genesis-dbc ~/.safe/genesis_dbc
+	cp workspace/alpha/network-contacts ~/.safe/network_contacts/default
+	cp workspace/alpha/genesis-dbc ~/.safe/genesis_dbc
 
 clean-alpha:
 	terraform workspace select alpha
 	./down.sh "${SN_TESTNET_SSH_KEY_PATH}" "-auto-approve"
 
 beta:
-	rm -f beta-*
+	rm -rf workspace/beta
+	mkdir -p workspace/beta
 	rm -rf .terraform
 	terraform init
 	terraform workspace select beta
@@ -38,8 +40,8 @@ beta:
 		"-auto-approve"
 	rm -rf ~/.safe
 	mkdir -p ~/.safe/network_contacts
-	cp beta-network-contacts ~/.safe/network_contacts/default
-	cp beta-genesis-dbc ~/.safe/genesis_dbc
+	cp workspace/beta/network-contacts ~/.safe/network_contacts/default
+	cp workspace/beta/genesis-dbc ~/.safe/genesis_dbc
 
 clean-beta:
 	terraform workspace select beta


### PR DESCRIPTION
The `NODE_BIN_PATH` argument had been changed to assume a custom binary located at `workspace/${testnet_channel}/sn_node`. However, we still need to be able to use the custom location for use with the testnet custom action. I also personally use full paths to node binaries located in the directory where I have `safe_network` code checked out.

This change will check if the `NODE_BIN_PATH` argument is set, and if not, it will look for a binary in the workspace directory.