### PR TITLE
fix: use repeating loop for metricbeat install

### DIFF
--- a/scripts/ELK/install-and-run-metricbeat.sh
+++ b/scripts/ELK/install-and-run-metricbeat.sh
@@ -1,36 +1,48 @@
 #!/bin/bash
 
-# Add gpg keys and install Metricbeat
+function install_metricbeat() {
+  sudo DEBIAN_FRONTEND=noninteractive apt update > /dev/null 2>&1
+  retry_count=1
+  metricbeat_installed="false"
+  while [[ $retry_count -le 20 ]]; do
+    echo "Attempting to install metricbeat..."
+    sudo DEBIAN_FRONTEND=noninteractive apt install metricbeat -y > /dev/null 2>&1
+    local exit_code=$?
+    if [[ $exit_code -eq 0 ]]; then
+        echo "metricbeat installed successfully"
+        metricbeat_installed="true"
+        break
+    fi
+    echo "Failed to install metricbeat."
+    echo "Attempted $retry_count times. Will retry up to 20 times. Sleeping for 10 seconds."
+    ((retry_count++))
+    sleep 10
+    # Without running this again there are times when it will just fail on every retry.
+    sudo DEBIAN_FRONTEND=noninteractive apt update > /dev/null 2>&1
+  done
+  if [[ "$metricbeat_installed" == "false" ]]; then
+    echo "Failed to install metricbeat"
+    exit 1
+  fi
+}
+
 echo "Setting up gpg keys"
 wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | sudo gpg --dearmor -o /usr/share/keyrings/elasticsearch-keyring.gpg
-
-# Write to source
 echo "deb [signed-by=/usr/share/keyrings/elasticsearch-keyring.gpg] https://artifacts.elastic.co/packages/8.x/apt stable main" | sudo tee /etc/apt/sources.list.d/elastic-8.x.list
 
-# Update and install metricbeat
-echo "Installing Metricbeat"
-sudo apt-get update > /dev/null 2>&1
-sudo apt-get install metricbeat > /dev/null 2>&1
+install_metricbeat
 
-# Remove default config
 rm -rf /etc/metricbeat/metricbeat.yml
 
-# Pull metricbeat config file from s3
 metric_beat_url="https://sn-node.s3.eu-west-2.amazonaws.com/testnet_tool/metricbeat.yml"
 wget ${metric_beat_url} -O metricbeat.yml
 
-# Get hostname
-name=$(hostname)
+sed -e "s/<MACHINE-NAME>/$(hostname)/g" metricbeat.yml > /etc/metricbeat/metricbeat.yml
 
-# Search and replace hostname in config
-sed -e "s/<MACHINE-NAME>/${name}/g" metricbeat.yml > /etc/metricbeat/metricbeat.yml
-
-# Cleanup residual config
 rm metricbeat.yml
 
 # small wait to avoid missing file errors starting up
 sleep 5
 
-# Start the service
 systemctl start metricbeat
 systemctl enable metricbeat


### PR DESCRIPTION
This installation seems to randomly fail a lot now, so wrapping the install in a loop.

Also remove superfluous comments from the script.