### PR TITLE
chore: configure node for new argument usage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ SHELL := /bin/bash
 SN_TESTNET_SSH_KEY_PATH := ~/.ssh/id_rsa
 SN_TESTNET_NODE_COUNT := 15
 SN_TESTNET_CLIENT_COUNT := 0
-SN_TESTNET_OTLP_COLLECTOR_ENDPOINT := http://dev-testnet-infra-1b6878ebf479584e.elb.eu-west-2.amazonaws.com:4317
+SN_TESTNET_OTLP_COLLECTOR_ENDPOINT := http://dev-testnet-infra-c4ea6d8bfbfeab40.elb.eu-west-2.amazonaws.com:4317
 
 alpha:
 	rm -rf workspace/alpha

--- a/aws/ansible/roles/node/templates/sn_node.service.j2
+++ b/aws/ansible/roles/node/templates/sn_node.service.j2
@@ -4,13 +4,12 @@ Description=Safe Node
 [Service]
 {% if is_genesis == "true" %}
 ExecStart=heaptrack {{ node_archive_dest_path }}/sn_node \
-  --first \
-  --local-addr {{ ansible_default_ipv4.address }}:{{ node_port }} \
+  --first {{ instance_public_ip }}:{{ node_port }} \
+  --local-addr 0.0.0.0:{{ node_port }} \
   --root-dir {{ node_data_dir_path }} \
   --log-dir {{ node_logs_dir_path }}
 {% else %}
 ExecStart=heaptrack {{ node_archive_dest_path }}/sn_node \
-  --local-addr {{ ansible_default_ipv4.address }}:{{ node_port }} \
   --network-contacts-file {{ network_contacts_path }} \
   --root-dir {{ node_data_dir_path }} \
   --log-dir {{ node_logs_dir_path }}

--- a/scripts/init-node.sh
+++ b/scripts/init-node.sh
@@ -106,8 +106,8 @@ function run_node() {
   if [[ "$is_genesis" == "true" ]]; then
     node_cmd=$(printf '%s' \
       "heaptrack ./sn_node " \
-      "--first " \
-      "--local-addr $node_ip_address:$port " \
+      "--first $node_ip_address:$port " \
+      "--local-addr 0.0.0.0:$port " \
       "--root-dir ~/node_data " \
       "--log-dir ~/logs " \
       "$log_level" \


### PR DESCRIPTION
The `--first` argument for the node now requires an IP address, and we discovered that it also requires `--local-addr` to be set to `0.0.0.0`.

This has been changed for both DO and AWS. I was able to run a testnet successfully on both providers, using public IP addresses.