### PR TITLE
feat: run testnets on aws with new safenode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ addresses/*
 aws/ansible/network-contacts
 aws/ansible/inventory/.*
 aws/.env
+aws/safenode_rpc_client
 
 # IDE
 .idea/

--- a/aws/Justfile
+++ b/aws/Justfile
@@ -2,14 +2,46 @@
 set dotenv-load := true
 enable_client := "false"
 
+# Build a copy of the RCP client, which is used for obtaining the genesis peer ID.
+# If the binary is already in the current directory we will skip.
+build-rpc-client:
+  #!/usr/bin/env bash
+  if [[ ! -f ./safenode_rpc_client ]]; then
+    (
+      cd /tmp
+      git clone https://github.com/maidsafe/safe_network
+      cd safe_network
+      cargo build --release --example safenode_rpc_client
+    )
+    cp /tmp/safe_network/target/release/examples/safenode_rpc_client .
+  else
+    echo "The safenode_rpc_client binary is already present"
+  fi
+
+# Initialise the prequisites for creating the testnet:
+# * Create a workspace for Terraform
+# * Build the RCP client
+# * Generate the inventory based on the template
+# * Create an EC2 keypair based on the key at SSH_PUBLIC_KEY_PATH
+#
+# This should be an idempotent target, in that it won't produce errors if any
+# of the components already exist.
 init name:
   #!/usr/bin/env bash
-  set -e
+
   (
     cd terraform
-    echo "Creating new Terraform workspace for the testnet..."
-    terraform workspace new {{name}}
+    terraform init
+    terraform workspace list | grep -q "{{name}}"
+    if [[ $? -eq 0 ]]; then
+      echo "Workspace '{{name}}' already exists"
+    else
+      echo "Creating new Terraform workspace {{name}}"
+      terraform workspace new {{name}}
+    fi
   )
+
+  just build-rpc-client
 
   cp ansible/inventory/dev_genesis_inventory_aws_ec2.yml \
     ansible/inventory/.{{name}}_genesis_inventory_aws_ec2.yml
@@ -24,10 +56,15 @@ init name:
     ansible/inventory/.{{name}}_inventory_aws_ec2.yml
   sed "s/dev/{{name}}/g" -i ansible/inventory/.{{name}}_inventory_aws_ec2.yml
 
-  pub_key=$(cat $SSH_PUBLIC_KEY_PATH | base64 -w0 | xargs)
-  echo "Creating new key pair for the testnet..."
-  aws ec2 import-key-pair \
-    --key-name testnet-{{name}} --public-key-material $pub_key
+  key_name="testnet-{{name}}"
+  if ! aws ec2 describe-key-pairs --key-names "$key_name" > /dev/null 2>&1; then
+    pub_key=$(cat $SSH_PUBLIC_KEY_PATH | base64 -w0 | xargs)
+    echo "Creating new key pair for the testnet..."
+    aws ec2 import-key-pair \
+      --key-name testnet-{{name}} --public-key-material $pub_key
+  else
+    echo "An EC2 keypair for {{name}} already exists"
+  fi
 
 run-ansible-against-nodes name="" node_bin_path="" is_genesis="":
   #!/usr/bin/env bash
@@ -37,9 +74,18 @@ run-ansible-against-nodes name="" node_bin_path="" is_genesis="":
     inventory_path="inventory/.{{name}}_genesis_inventory_aws_ec2.yml"
     extra_vars="is_genesis={{is_genesis}}"
   else
+    # Construct the multiaddr for the genesis node.
+    cd ansible
+    genesis_ip=$(ansible-inventory --inventory inventory/.{{name}}_genesis_inventory_aws_ec2.yml --list | \
+      jq -r '.["_meta"]["hostvars"][]["public_ip_address"]')
+    cd ..
+    peer_id=$(./safenode_rpc_client $genesis_ip:12001 info | \
+      grep "Peer Id" | awk -F ':' '{ print $2 }' | xargs)
+    multiaddr="/ip4/$genesis_ip/udp/12000/quic-v1/p2p/$peer_id"
+
     playbook="nodes.yml"
     inventory_path="inventory/.{{name}}_node_inventory_aws_ec2.yml"
-    extra_vars="is_genesis={{is_genesis}}"
+    extra_vars="{'is_genesis': '{{is_genesis}}', 'genesis_multiaddr': '$multiaddr'}"
   fi
   if [[ ! -z "{{node_bin_path}}" ]]; then
     if [[ ! -f "{{node_bin_path}}" ]]; then
@@ -47,7 +93,7 @@ run-ansible-against-nodes name="" node_bin_path="" is_genesis="":
       exit 1
     fi
     echo "Using custom node binary at {{node_bin_path}}"
-    extra_vars="{'is_genesis': '{{is_genesis}}', 'node_bin_path': '{{node_bin_path}}'}"
+    extra_vars="{'is_genesis': '{{is_genesis}}', 'node_bin_path': '{{node_bin_path}}', 'genesis_multiaddr': '$multiaddr'}"
   fi
   just run-ansible "$inventory_path" "$playbook" "$extra_vars"
 
@@ -68,7 +114,6 @@ testnet name node_count node_bin_path="":
   #!/usr/bin/env bash
   set -e
   (
-    # Create the EC2 instances
     cd terraform
     terraform init
     terraform workspace select {{name}}
@@ -79,17 +124,12 @@ testnet name node_count node_bin_path="":
       -var vpc_security_group_id="$SN_TESTNET_DEV_SECURITY_GROUP_ID" \
       -var enable_client={{enable_client}}
   )
+
   # Provision the genesis node
   just run-ansible-against-nodes "{{name}}" "{{node_bin_path}}" "true"
-  # Obtain the network contacts file from the genesis node
-  just network-contacts "{{name}}"
-  # Provision the client node
-  just run-ansible "inventory/.{{name}}_client_inventory_aws_ec2.yml" "client.yml"
+
   # Provision the remaining nodes
   just run-ansible-against-nodes "{{name}}" "{{node_bin_path}}" "false"
-
-network-contacts name:
-  just run-ansible "inventory/.{{name}}_genesis_inventory_aws_ec2.yml" "network_contacts.yml"
 
 ssh-details name:
   @ansible-inventory --inventory ansible/inventory/.{{name}}_inventory_aws_ec2.yml --list | \

--- a/aws/README.md
+++ b/aws/README.md
@@ -27,8 +27,8 @@ AWS_DEFAULT_REGION=eu-west-2
 ANSIBLE_VAULT_PASSWORD_PATH=<path>
 SSH_PRIVATE_KEY_PATH=<path>
 SSH_PUBLIC_KEY_PATH=<path>
-SN_TESTNET_DEV_SUBNET_ID=subnet-038968af46e82a7c9
-SN_TESTNET_DEV_SECURITY_GROUP_ID=sg-0ad9341d486c81e38
+SN_TESTNET_DEV_SUBNET_ID=subnet-018f2ab26755df7f9
+SN_TESTNET_DEV_SECURITY_GROUP_ID=sg-0d47df5b3f0d01e2a
 ```
 
 The EC2 instances need to be launched with an SSH key pair. You can either generate a new key pair or use an existing one. In either case, set `SSH_PUBLIC_KEY_PATH` to the location of the public key. The `SSH_PRIVATE_KEY_PATH` should be set to the corresponding private key, since Ansible will use this. Similarly, set `ANSIBLE_VAULT_PASSWORD_PATH` to the location where you put the password file.
@@ -62,6 +62,15 @@ There are various utility targets that can be called:
 * `just ssh-details`: will print out a list of all the nodes and their public IP addresses, which you can then use to SSH to any node, using your private key and the `ubuntu` user.
 * `just logs alpha`: will get the logs from all the machines in the testnet and make them available in a `logs` directory locally.
 * `just network-contacts alpha`: will copy the network contacts file from the genesis node to the local machine.
+
+The node runs as a service, so it's possible to SSH to the instance and view its logs using `journalctl`:
+```
+journalctl -u safenode # print the log with paging
+journalctl -f -u safenode # follow the log while it's updating
+journalctl -u safenode -o cat --no-pager # print the whole log without paging
+```
+
+This can be useful for quick debugging.
 
 ## Teardown
 

--- a/aws/ansible/genesis_node.yml
+++ b/aws/ansible/genesis_node.yml
@@ -1,5 +1,6 @@
 ---
-- hosts: all
+- name: deploy safenode to genesis node
+  hosts: all
   become: False
   roles:
     - role: prerequisites

--- a/aws/ansible/nodes.yml
+++ b/aws/ansible/nodes.yml
@@ -1,20 +1,5 @@
 ---
-- name: copy network contacts to nodes
-  hosts: all
-  tasks:
-    - name: ensure .safe directory exists
-      ansible.builtin.file:
-        path: "/home/{{ ansible_user }}/.safe"
-        owner: "{{ ansible_user }}"
-        group: "{{ ansible_user }}"
-        state: directory
-    - name: copy network contacts to nodes
-      copy:
-        src: network-contacts
-        dest: /home/{{ ansible_user }}/.safe/network-contacts
-        owner: "{{ ansible_user }}"
-        group: "{{ ansible_user }}"
-- name: deploy safe node
+- name: deploy safenode to remaining nodes
   hosts: all
   become: False
   roles:

--- a/aws/ansible/roles/node/defaults/main.yml
+++ b/aws/ansible/roles/node/defaults/main.yml
@@ -2,12 +2,12 @@
 is_genesis: False
 otlp_endpoint: http://telemetry-collector.dev-testnet-infra.local:4317
 safe_settings_path: /home/{{ ansible_user }}/.safe
-network_contacts_path: "{{ safe_settings_path }}/network-contacts"
-node_archive_filename: sn_node-latest-x86_64-unknown-linux-musl.tar.gz
+node_archive_filename: safenode-latest-x86_64-unknown-linux-musl.tar.gz
 node_archive_url: https://sn-node.s3.eu-west-2.amazonaws.com/{{ node_archive_filename }}
 node_archive_dest_path: /usr/local/bin
 node_port: 12000
+node_rpc_port: 12001
 node_data_dir_path: /home/{{ ansible_user }}/node_data
 node_logs_dir_path: /mnt/node_logs/logs
-rust_log_setting: sn_node=trace,sn_fault_detection=trace,sn_interface=trace
-rust_log_otlp_setting: sn_node=trace,sn_fault_detection=trace,sn_interface=trace
+rust_log_setting: safenode=trace
+rust_log_otlp_setting: safenode=trace

--- a/aws/ansible/roles/node/tasks/main.yml
+++ b/aws/ansible/roles/node/tasks/main.yml
@@ -25,7 +25,7 @@
 # The `instance_public_ip` is also used in the service definition file.
 - name: get the public IP for the instance
   set_fact:
-    instance_public_ip: "{{ instance_facts.instances[0].network_interfaces[0].association.public_ip }}"
+    instance_private_ip: "{{ instance_facts.instances[0].network_interfaces[0].private_ip_address }}"
 
 - name: copy the custom node binary from the local machine
   become: True
@@ -68,7 +68,7 @@
   become: True
   template:
     src: sn_node.service.j2
-    dest: /etc/systemd/system/sn_node.service
+    dest: /etc/systemd/system/safenode.service
 
 - name: reload the system manager configuration
   become: True
@@ -77,5 +77,5 @@
 - name: start the node service
   become: True
   service:
-    name: sn_node
+    name: safenode
     state: started

--- a/aws/ansible/roles/node/templates/sn_node.service.j2
+++ b/aws/ansible/roles/node/templates/sn_node.service.j2
@@ -3,16 +3,15 @@ Description=Safe Node
 
 [Service]
 {% if is_genesis == "true" %}
-ExecStart=heaptrack {{ node_archive_dest_path }}/sn_node \
-  --first {{ instance_public_ip }}:{{ node_port }} \
-  --local-addr 0.0.0.0:{{ node_port }} \
+ExecStart={{ node_archive_dest_path }}/safenode \
   --root-dir {{ node_data_dir_path }} \
-  --log-dir {{ node_logs_dir_path }}
+  --port {{ node_port }} \
+  --rpc {{ instance_private_ip }}:{{ node_rpc_port }}
 {% else %}
-ExecStart=heaptrack {{ node_archive_dest_path }}/sn_node \
-  --network-contacts-file {{ network_contacts_path }} \
+ExecStart={{ node_archive_dest_path }}/safenode \
   --root-dir {{ node_data_dir_path }} \
-  --log-dir {{ node_logs_dir_path }}
+  --port {{ node_port }} \
+  --peer {{ genesis_multiaddr }}
 {% endif %}
 Environment=RUST_LOG={{ rust_log_setting }} \
   RUST_LOG_OTLP={{ rust_log_otlp_setting }} \


### PR DESCRIPTION
The process for bringing up a testnet with the new `safenode` is as follows:

* Launch all the EC2 instances with Terraform
* Deploy `safenode` on the genesis node
* Use the RPC service to get the peer ID of the genesis node
* Deploy `safenode` on the remaining nodes using the peer ID

It turns out to actually be a bit simpler than the old process.