### PR TITLE
chore: provide the otlp endpoint

### DIFF
--- a/aws/README.md
+++ b/aws/README.md
@@ -59,9 +59,8 @@ This makes use of the additional disk since the default disk has hardly any spac
 
 There are various utility targets that can be called:
 
-* `just ssh-details`: will print out a list of all the nodes and their public IP addresses, which you can then use to SSH to any node, using your private key and the `ubuntu` user.
-* `just logs alpha`: will get the logs from all the machines in the testnet and make them available in a `logs` directory locally.
-* `just network-contacts alpha`: will copy the network contacts file from the genesis node to the local machine.
+* `just ssh-details "<name>"`: will print out a list of all the nodes and their public IP addresses, which you can then use to SSH to any node, using your private key and the `ubuntu` user.
+* `just logs "<name>"`: will get the logs from all the machines in the testnet and make them available in a `logs` directory locally.
 
 The node runs as a service, so it's possible to SSH to the instance and view its logs using `journalctl`:
 ```

--- a/aws/ansible/roles/node/defaults/main.yml
+++ b/aws/ansible/roles/node/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 is_genesis: False
-otlp_endpoint: http://telemetry-collector.dev-testnet-infra.local:4317
+otlp_endpoint: http://dev-testnet-infra-b913fd1863ae4271.elb.eu-west-2.amazonaws.com:4317
 safe_settings_path: /home/{{ ansible_user }}/.safe
 node_archive_filename: safenode-latest-x86_64-unknown-linux-musl.tar.gz
 node_archive_url: https://sn-node.s3.eu-west-2.amazonaws.com/{{ node_archive_filename }}

--- a/aws/ansible/roles/node/templates/sn_node.service.j2
+++ b/aws/ansible/roles/node/templates/sn_node.service.j2
@@ -5,11 +5,13 @@ Description=Safe Node
 {% if is_genesis == "true" %}
 ExecStart={{ node_archive_dest_path }}/safenode \
   --root-dir {{ node_data_dir_path }} \
+  --log-dir {{ node_logs_dir_path }} \
   --port {{ node_port }} \
   --rpc {{ instance_private_ip }}:{{ node_rpc_port }}
 {% else %}
 ExecStart={{ node_archive_dest_path }}/safenode \
   --root-dir {{ node_data_dir_path }} \
+  --log-dir {{ node_logs_dir_path }} \
   --port {{ node_port }} \
   --peer {{ genesis_multiaddr }}
 {% endif %}


### PR DESCRIPTION
This location will be static while this Opensearch instance remains online.