### PR TITLE
fix: invalid environment variables

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -12,4 +12,4 @@ docker run --rm --interactive --tty \
   --volume $HOME/.ansible:/home/runner/.ansible \
   --volume $HOME/.ssh:/home/runner/.ssh \
   --volume $(pwd):/home/runner/sn_testnet_tool \
-  sn_testnet_tool:latest $@
+  jacderida/sn_testnet_tool:latest $@

--- a/terraform/digital-ocean/variables.tf
+++ b/terraform/digital-ocean/variables.tf
@@ -21,7 +21,7 @@ variable "droplet_size" {
 }
 
 variable "droplet_image" {
-  default = "ubuntu-22-04-x64"
+  default = "ubuntu-22-10-x64"
 }
 
 variable "region" {

--- a/up.sh
+++ b/up.sh
@@ -41,8 +41,8 @@ docker run --rm \
   jacderida/sn_testnet_tool:latest just init $env $provider
 docker run --rm --tty \
   --env AWS_ACCESS_KEY_ID --env AWS_SECRET_ACCESS_KEY --env AWS_DEFAULT_REGION \
-  --env SSH_KEY_NAME --env DIGITALOCEAN_TOKEN --env DO_API_TOKEN \
-  --env SN_TESTNET_DEV_SUBNET_ID --env SN_TESTNET_DEV_SECURITY_GROUP_ID \
+  --env SSH_KEY_NAME --env DO_PAT --env SN_TESTNET_DEV_SUBNET_ID \
+  --env SN_TESTNET_DEV_SECURITY_GROUP_ID \
   --volume $HOME/.ansible:/home/runner/.ansible \
   --volume $HOME/.ssh:/home/runner/.ssh \
   --volume $(pwd):/home/runner/sn_testnet_tool \


### PR DESCRIPTION
- b6e9efc **fix: invalid environment variables**

  The `init` and `testnet` targets were passing different environment variables for Digital Ocean.

  Also fixes the reference to the container in the run script to prevent the need for building
  locally.

- 21efe4d **feat: use ubuntu 22.10 on digital ocean**

  There seemed to be some change in the 22.04 base image that was causing locks during an apt-get
  update. The same problem doesn't seem present on 22.10.