### PR TITLE
feat: run multiple node services on single vm

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -37,7 +37,7 @@ init env provider:
   just create-{{provider}}-inventory {{env}}
   just create-{{provider}}-keypair {{env}}
 
-testnet env provider node_count custom_bin org="" branch="":
+testnet env provider node_count node_instance_count="10" use_custom_bin="false" org="" branch="":
   #!/usr/bin/env bash
   set -e
   (
@@ -54,9 +54,11 @@ testnet env provider node_count custom_bin org="" branch="":
     sed "s|__NODE_ARCHIVE__|{{custom_bin_archive_filename}}|g" -i ansible/extra_vars/.{{env}}_{{provider}}.json
     url="https://sn-node.s3.eu-west-2.amazonaws.com/{{org}}/{{branch}}/{{custom_bin_archive_filename}}"
     sed "s|__NODE_URL__|$url|g" -i ansible/extra_vars/.{{env}}_{{provider}}.json
+    sed "s|__NODE_INSTANCE_COUNT__|{{node_instance_count}}|g" -i ansible/extra_vars/.{{env}}_{{provider}}.json
   else
     sed "s|__NODE_ARCHIVE__|{{default_node_archive_filename}}|g" -i ansible/extra_vars/.{{env}}_{{provider}}.json
     sed "s|__NODE_URL__|{{default_node_url}}|g" -i ansible/extra_vars/.{{env}}_{{provider}}.json
+    sed "s|__NODE_INSTANCE_COUNT__|{{node_instance_count}}|g" -i ansible/extra_vars/.{{env}}_{{provider}}.json
   fi
 
   just wait-for-ssh "{{env}}" "{{provider}}"

--- a/ansible/extra_vars/digital_ocean.json
+++ b/ansible/extra_vars/digital_ocean.json
@@ -4,6 +4,7 @@
 	"node_archive_url": "__NODE_URL__",
 	"node_data_dir_path": "/home/safe/.local/share/safe/node/data",
 	"node_logs_dir_path": "/home/safe/.local/share/safe/node/logs",
+	"node_instance_count": "__NODE_INSTANCE_COUNT__",
 	"provider": "digital-ocean",
 	"org": "__ORG__",
 	"branch": "__BRANCH__"

--- a/ansible/roles/node/defaults/main.yml
+++ b/ansible/roles/node/defaults/main.yml
@@ -6,6 +6,7 @@ node_archive_url: https://sn-node.s3.eu-west-2.amazonaws.com/{{ node_archive_fil
 node_archive_dest_path: /usr/local/bin
 node_port: 12000
 node_rpc_port: 12001
+node_instance_count: 10
 node_data_dir_path: /home/safe/.local/share/safe/node/data
 node_logs_dir_path: /home/safe/.local/share/safe/node/logs
 rust_log_setting: safenode=trace

--- a/ansible/roles/node/tasks/main.yml
+++ b/ansible/roles/node/tasks/main.yml
@@ -60,34 +60,30 @@
     dest: "{{ node_archive_dest_path }}"
     remote_src: True
 
-- name: create the data directory
-  become: True
-  ansible.builtin.file:
-    path: "{{ node_data_dir_path }}"
-    owner: "safe"
-    group: "safe"
-    state: directory
-
-- name: create the logs directory
-  become: True
-  ansible.builtin.file:
-    path: "{{ node_logs_dir_path }}"
-    owner: "safe"
-    group: "safe"
-    state: directory
-
 - name: copy service file
   become: True
   template:
     src: sn_node.service.j2
-    dest: /etc/systemd/system/safenode.service
+    dest: /etc/systemd/system/safenode@.service
+  register: service_template_created
 
 - name: reload the system manager configuration
   become: True
   command: systemctl daemon-reload
+  when: service_template_created.changed
 
-- name: start the node service
+- name: start the node services
   become: True
-  service:
-    name: safenode
+  systemd:
+    name: safenode@{{ item }}
     state: started
+  loop: "{{ range(1, (node_instance_count | int) + 1)|list }}"
+  when: not is_genesis
+
+- name: start the genesis node service
+  become: True
+  systemd:
+    name: safenode@1
+    state: started
+    enabled: yes
+  when: is_genesis

--- a/ansible/roles/node/templates/sn_node.service.j2
+++ b/ansible/roles/node/templates/sn_node.service.j2
@@ -1,5 +1,5 @@
 [Unit]
-Description=Safe Node
+Description=Safe Node %I
 
 [Service]
 {% if is_genesis %}
@@ -9,12 +9,12 @@ ExecStart={{ node_archive_dest_path }}/safenode \
   --rpc {{ node_rpc_ip }}:{{ node_rpc_port }}
 {% else %}
 ExecStart={{ node_archive_dest_path }}/safenode \
-  --port {{ node_port }} \
+  --log-output-dest data-dir \
   --peer {{ genesis_multiaddr }}
 {% endif %}
 Environment=RUST_LOG={{ rust_log_setting }} \
   RUST_LOG_OTLP={{ rust_log_otlp_setting }} \
-  OTLP_SERVICE_NAME={{ instance_name }} \
+  OTLP_SERVICE_NAME={{ instance_name }}-%I \
   OTEL_EXPORTER_OTLP_ENDPOINT={{ otlp_endpoint }}
 User=safe
 

--- a/ansible/roles/prerequisites/tasks/main.yml
+++ b/ansible/roles/prerequisites/tasks/main.yml
@@ -3,6 +3,7 @@
   apt:
     update_cache: yes
 
+# The retries are for random lock failures.
 - name: install packages
   ansible.builtin.package:
     name: "{{ item }}"
@@ -12,6 +13,10 @@
     - python3
     - python3-pip
     - zip
+  register: result
+  until: result is succeeded
+  retries: 3
+  delay: 5
 
 - name: install boto3
   ansible.builtin.pip:

--- a/ansible/roles/rust/tasks/main.yml
+++ b/ansible/roles/rust/tasks/main.yml
@@ -1,4 +1,5 @@
 ---
+# The retries are for random lock failures.
 - name: install build-essential and musl
   become: True
   ansible.builtin.package:

--- a/ansible/roles/rust/tasks/main.yml
+++ b/ansible/roles/rust/tasks/main.yml
@@ -8,6 +8,10 @@
     - build-essential
     - musl
     - musl-tools
+  register: result
+  until: result is succeeded
+  retries: 3
+  delay: 5
 
 - name: install rustup and musl target
   ansible.builtin.shell: |

--- a/terraform/digital-ocean/variables.tf
+++ b/terraform/digital-ocean/variables.tf
@@ -22,7 +22,7 @@ variable "droplet_size" {
 }
 
 variable "build_machine_size" {
-  default = "s-4vcpu-8gb"
+  default = "s-8vcpu-16gb"
 }
 
 variable "droplet_image" {

--- a/up.sh
+++ b/up.sh
@@ -27,17 +27,15 @@ if [[ -z "$node_instance_count" ]]; then
   exit 1
 fi
 
-custom_bin="$5"
-
-org="$6"
-if [[ "$custom_bin" = true && -z "$org" ]]; then
-  echo "If using a custom binary the Github organisation or user must be provided"
-  exit 1
+custom_bin="false"
+org="$5"
+if [[ ! -z "$org" ]]; then
+  custom_bin="true"
 fi
 
-branch="$7"
+branch="$6"
 if [[ "$custom_bin" = true && -z "$branch" ]]; then
-  echo "If using a custom binary the Github branch must be provided"
+  echo "If you wish to use a custom binary you must supply the repo org and branch as arguments."
   exit 1
 fi
 

--- a/up.sh
+++ b/up.sh
@@ -20,15 +20,22 @@ if [[ -z "$node_count" ]]; then
   exit 1
 fi
 
-custom_bin="$4"
+node_instance_count="$4"
+if [[ -z "$node_instance_count" ]]; then
+  echo "The number of node service instances must be provided."
+  echo "This is the number of node services that run on each VM."
+  exit 1
+fi
 
-org="$5"
+custom_bin="$5"
+
+org="$6"
 if [[ "$custom_bin" = true && -z "$org" ]]; then
   echo "If using a custom binary the Github organisation or user must be provided"
   exit 1
 fi
 
-branch="$6"
+branch="$7"
 if [[ "$custom_bin" = true && -z "$branch" ]]; then
   echo "If using a custom binary the Github branch must be provided"
   exit 1
@@ -53,4 +60,5 @@ docker run --rm --tty \
   --volume $HOME/.ansible:/home/runner/.ansible \
   --volume $HOME/.ssh:/home/runner/.ssh \
   --volume $(pwd):/home/runner/sn_testnet_tool \
-  jacderida/sn_testnet_tool:latest just testnet $env $provider $node_count $custom_bin $org $branch
+  jacderida/sn_testnet_tool:latest just testnet \
+    $env $provider $node_count $node_instance_count $custom_bin $org $branch


### PR DESCRIPTION
- 243202c **feat: run multiple node services on single vm**

  Using systemd it is actually quite simple to run multiple instances of the same service.

  It has also been made simple by recent changes we've made in the node for providing default
  directories for root and logging, and the fact that the node can select an unused port for us.

- d07b8e7 **feat: change interface to `up.sh` script**

  Remove the need to pass a "true" value for indicating use of a custom binary, and just use the
  presence of the org and branch arguments.

- 1d6b24d **feat: retries for package installations**

  Installing packages with the Ansible module is subject to the same failures as it is in the shell,
  namely the dpkg file being locked. A few retries are added, which almost always overcomes the
  issue.

  Also only run the build node provision conditionally.
  
- 71d0239 **chore: use larger VM for build machine**

  The VM with 4vCPU and 8GB of RAM still seemed a bit slow for the `safe_network` build.